### PR TITLE
modbuilder/plugins/hide_save_indicator.py: added

### DIFF
--- a/modbuilder/plugins/hide_save_indicator.py
+++ b/modbuilder/plugins/hide_save_indicator.py
@@ -1,0 +1,31 @@
+from modbuilder import mods
+
+
+DEBUG = False
+NAME = "Hide Save Indicator"
+DESCRIPTION = "Hide the indicator shown in the lower-left corner of the screen while the game saves. Saving is not disabled."
+OPTIONS = [
+  { "title": "There are no options. Just add the modification." }
+]
+
+# This Scaleform-generated texture name may change after a game update. Keep it
+# synchronized with the UI assets shipped in the matching org asset bundle.
+SAVE_INDICATOR_FILE = "overlay_i5d.ddsc"
+ASSETS_PATH = mods.APP_DIR_PATH / "org/modded/hide_save_indicator"
+REPLACEMENT_FILE = ASSETS_PATH / "transparent.ddsc"
+
+
+def format_options(options: dict) -> str:
+  return NAME
+
+
+def get_files(options: dict) -> list[str]:
+  return []
+
+
+def merge_files(files: list[str], options: dict) -> None:
+  mods.copy_file(REPLACEMENT_FILE, mods.MOD_PATH / "ui" / SAVE_INDICATOR_FILE)
+
+
+def update_values_at_offset(options: dict) -> list[dict]:
+  return []


### PR DESCRIPTION
## Summary

Adds a new **Hide Save Indicator** plugin that removes the lower-left indicator displayed while the game is saving.

<img width="72" height="76" alt="save_icon" src="https://github.com/user-attachments/assets/070a4e5d-17ba-415b-8b7f-ed453b658b04" />

Personally, I find this indicator quite distracting, as it appears roughly every 10 seconds and breaks immersion. I am not alone with this opinion, see [steamcommunity.com Remove autosave icon!](https://steamcommunity.com/app/518790/discussions/2/3016788637310646060/) and [nexusmods.com Hexagon is GONE](https://www.nexusmods.com/thehuntercallofthewild/mods/582).


Saving functionality itself is unaffected.

⚠ This requires a new modded asset:

```text
org/modded/hide_save_indicator/transparent.ddsc
```

[hide_save_indicator_asset.zip](https://github.com/user-attachments/files/29202969/hide_save_indicator_asset.zip)


## Maintenance Note

The save indicator is storedin `overlay_i5d.ddsc`, a filename that has remained unchanged throughout updates over the past two years or so, though it may change in future releases.

